### PR TITLE
Typo and naming convention corrections draft

### DIFF
--- a/workshop/content/40-reinvent2019/100-task-1/100-create-the-control.md
+++ b/workshop/content/40-reinvent2019/100-task-1/100-create-the-control.md
@@ -80,7 +80,7 @@ Portfolios:
   </figure>
 
  
-- Set the *File name* to `portfolios/reinvent.yaml`
+- Set the *File name* to *portfolios/reinvent.yaml*
 
 - Set your *Author name*
 - Set your *Email address*

--- a/workshop/content/design-considerations/account-tagging/_index.md
+++ b/workshop/content/design-considerations/account-tagging/_index.md
@@ -31,7 +31,7 @@ accounts:
  
  The tags assigned to this account are *type:prod* and *partition:eu*.
 
-These tags are later used in the `launches` and `spoke-portfolio-shares` sections of the manifest file to choose which 
+These tags are later used in the *launches* and *spoke-portfolio-shares* sections of the manifest file to choose which 
 AWS Accounts should have products provisioned into them and which AWS Accounts should have portfolios shared with them:
 
 <figure>
@@ -56,18 +56,18 @@ spoke-local-portfolios:
   {{< / highlight >}}
  </figure>          
  
-The Service Catalog Tools looks through the `launches` and the `spoke-local-portfolios`.  For each `launch` and 
-`spoke-local-portfolio` found the framework will look through the tags specified in the tags section.  For each tag found
+The Service Catalog Tools looks through the *launches* and the *spoke-local-portfolios*.  For each *launch* and 
+*spoke-local-portfolio* found the framework will look through the tags specified in the tags section.  For each tag found
 the Service Catalog Tools will look through the list of accounts for an account with the same tag.  When the tag is found
 the product is provisioned if the tag was found in the launch section otherwise the portfolio specified will be shared if
-the tag was found in a `spoke-local-portfolio`.
+the tag was found in a *spoke-local-portfolio*.
 
 ## How you can make best use of them
 
 Having the right number of tags is essential.  Too few tags will cause you to have less flexibility but having too many
 may lead to a larger than needed manifest file or feeling overwhelmed.
 
-To begin with, we recommend using `foundation` and `additional` tags to align to the multi-account strategy best practice:
+To begin with, we recommend using *foundation* and *additional* tags to align to the multi-account strategy best practice:
 
 - outype:foundational
 - outype:additional

--- a/workshop/content/design-considerations/account-tagging/_index.md
+++ b/workshop/content/design-considerations/account-tagging/_index.md
@@ -31,8 +31,8 @@ accounts:
  
  The tags assigned to this account are *type:prod* and *partition:eu*.
 
-These tags are later used in the launch and spoke-portfolio-shares sections of the manifest file to choose which 
-accounts should have produces provisioned into them and which accounts should have portfolios shared with them:
+These tags are later used in the `launches` and `spoke-portfolio-shares` sections of the manifest file to choose which 
+AWS Accounts should have products provisioned into them and which AWS Accounts should have portfolios shared with them:
 
 <figure>
   {{< highlight js "hl_lines=8 16" >}}
@@ -56,23 +56,23 @@ spoke-local-portfolios:
   {{< / highlight >}}
  </figure>          
  
-The Service Catalog Tools looks through the launches and the spoke-local-portfolios.  For each launch and 
-spoke-local-portfolio found the framework will look through the tags specified in the tags section.  For each tag found
+The Service Catalog Tools looks through the `launches` and the `spoke-local-portfolios`.  For each `launch` and 
+`spoke-local-portfolio` found the framework will look through the tags specified in the tags section.  For each tag found
 the Service Catalog Tools will look through the list of accounts for an account with the same tag.  When the tag is found
 the product is provisioned if the tag was found in the launch section otherwise the portfolio specified will be shared if
-the tag was found in a spoke-local-portfolio.
+the tag was found in a `spoke-local-portfolio`.
 
 ## How you can make best use of them
 
 Having the right number of tags is essential.  Too few tags will cause you to have less flexibility but having too many
 may lead to a larger than needed manifest file or feeling overwhelmed.
 
-To begin with, we recommend using foundation and additional tags to align to the multi account strategy best practice:
+To begin with, we recommend using `foundation` and `additional` tags to align to the multi-account strategy best practice:
 
 - outype:foundational
 - outype:additional
 
-We then recommend describing which ou the accounts are in:
+We then recommend describing which OU the AWS Accounts are in:
 
 - ou:sharedservices
 - ou:networking
@@ -88,7 +88,6 @@ We then recommend the following tags based on the type of the workloads that exi
 
 We then recommend using a set of scope tags to help explain the governance needs of the accounts:
 
-- scope:gdpr
 - scope:pci
 - scope:pii
 - scope:hipaa
@@ -104,5 +103,5 @@ The tags you specify within the manifest are not applied to the accounts using A
 within the manifest file.  You can change them at any time and renaming them will not result in changes.
 
 {{% notice note %}}
-If you would like to share your tagging patterns raise a github issue to share
+If you would like to share your tagging patterns raise a [github issue](https://github.com/aws-samples/aws-service-catalog-tools-workshop/issues) to share
 {{% /notice %}}

--- a/workshop/content/design-considerations/multi-account-strategy/_index.md
+++ b/workshop/content/design-considerations/multi-account-strategy/_index.md
@@ -7,18 +7,18 @@ weight = 50
 
 ## What are we going to do?
 
-This article will help you align your multi account strategy with best practices.
+This article will help you align your multi-account strategy with best practices.
 
 
 ## AWS Organizations
 
 AWS Organizations helps you centrally govern your environment as you grow and scale your workloads on AWS. Whether you 
-are a growing startup or a large enterprise, Organizations helps you to centrally manage billing; control access, 
+are a growing startup or a large enterprise, AWS Organizations helps you to centrally manage billing; control access, 
 compliance, and security; and share resources across your AWS accounts.
 
 Using AWS Organizations, you can automate account creation, create groups of accounts to reflect your business needs, 
 and apply policies for these groups for governance. You can also simplify billing by setting up a single payment method
-for all of your AWS accounts. Through integrations with other AWS services, you can use Organizations to define central 
+for all of your AWS accounts. Through integrations with other AWS services, you can use AWS Organizations to define central 
 configurations and resource sharing across accounts in your organization. AWS Organizations is available to all AWS 
 customers at no additional charge.
 

--- a/workshop/content/design-considerations/multi-account-strategy/starter-framework.md
+++ b/workshop/content/design-considerations/multi-account-strategy/starter-framework.md
@@ -7,20 +7,20 @@ weight = 10
 
 ## What are we going to do?
 
-This article will explain the starter multi account framework
+This article will explain the starter multi-account framework
 
 
 ## Starter framework
 
-Within your AWS Organization there are two types of Organizational units - foundational and additional.  
+Within your AWS Organization there are two types of Organizational Units (OUs) - foundational and additional.  
 
 The Foundational OUs group the shared accounts needed to manage the your overall AWS environment. The areas 
-considered Foundational are security, networking and security logs. Each of the Accounts within the Foundational OUs are 
+considered foundational are security, networking and logs. Each of the AWS Accounts within the foundational OUs are 
 grouped into production and non-production environments in order to clearly distinguish between production and non 
 production policies.
  
 
-The Additional OUs group the accounts directly related to the software development lifecycle. This includes the accounts
+The additional OUs group the accounts directly related to the software development lifecycle. This includes the accounts
 for development (development sandboxes, source code and continuous delivery) and the accounts for the staging process 
 from earliest testing to production.
 
@@ -51,7 +51,7 @@ extremely limited access, almost never be used and have an alert on login.
 
 ##### Tooling
 This account / these accounts would typically be owned by the security team and used to enable security operations. It 
-would would be used for tools such as AWS Guard Duty, AWS Security Hub, AWS Config aggregation or Cloud Custodian.  
+would would be used for tools such as AWS Guard Duty, AWS Security Hub, AWS Config aggregation or [Cloud Custodian](https://github.com/cloud-custodian/cloud-custodian).  
 There could be more than one tooling account.
 
 #### Infrastructure
@@ -59,7 +59,7 @@ There could be more than one tooling account.
 Infrastructure is intended for shared infrastructure services such as networking and optionally any shared hosted 
 infrastructure services.
 
-Accounts in other Foundational and Additional OUs should only depend on the infrastructure/prod OU accounts.
+Accounts in other foundational and additional OUs should only depend on the infrastructure/prod OU accounts.
 
 ##### Shared Services
 
@@ -79,7 +79,7 @@ This account / these accounts would typically host the following networking serv
 
 ### Additional
 
-The Additional OUs group the accounts directly related to the software development lifecycle. This includes the accounts
+The Additional OUs group the accounts directly related to the SDLC. This includes the accounts
 for development (development sandboxes, source code and continuous delivery) and the accounts for the staging process 
 from earliest testing to production.
 

--- a/workshop/content/design-considerations/portfolio-management/_index.md
+++ b/workshop/content/design-considerations/portfolio-management/_index.md
@@ -14,12 +14,12 @@ how you can best make use of them whilst using the Service Catalog Tools.
 
 Within AWS Service Catalog a portfolio is a logical grouping of products.
 
-It makes sense to group products that provision similar or complimentary resources together but this may not give you 
+It makes sense to group products that provision similar or complimentary resources together, but this may not give you 
 the flexibility you need:
 
-- Within Service Catalog you set associations at the portfolio level so by default when you grant access to a portfolio 
+- Within AWS Service Catalog you set associations at the portfolio level so by default when you grant access to a portfolio 
 all products can be seen.
-- Within Service Catalog you can share portfolios with other accounts.  You cannot share just a single product form a 
+- Within AWS Service Catalog you can share portfolios with other accounts.  You cannot share just a single product from a 
 portfolio. 
 
 ## How you can make best use of them
@@ -43,7 +43,7 @@ This normally results in at least two portfolios per team:
   
 The teams we have worked with normally group the products into mandatory products and self service products.  For 
 example, if the team using Service Catalog Tools is a cloud engineering / CCOE team they would provision products like
-AWS Security Hub enabler into an account - this would be mandatory.  If the same team had some optional products like
+AWS Security Hub Enabler into an account - this would be mandatory.  If the same team had some optional products like
 Encrypted S3 Bucket then this would go into an optional portfolio.  This results in the following structure:
 
 - team a
@@ -62,5 +62,5 @@ following names work well:
 - compulsory
 
 {{% notice note %}}
-If you would like to share your portfolio names raise a github issue to share
+If you would like to share your portfolio names raise a [github issue](https://github.com/aws-samples/aws-service-catalog-tools-workshop/issues) to share
 {{% /notice %}}

--- a/workshop/content/design-considerations/product-sdlc/_index.md
+++ b/workshop/content/design-considerations/product-sdlc/_index.md
@@ -7,12 +7,12 @@ weight = 400
 
 ## What are we going to do?
 
-This article will explain how productive teams have been structuring their AWS accounts and how they have been managing
+This article will explain how productive teams have been structuring their AWS Accounts and how they have been managing
 their source code whilst working with the Service Catalog Tools.
 
 ## AWS Account structure
 
-Testing the provisioning of a single resource in AWS can be achieved using CloudFormation RSpec, awspec and others.
+Testing the provisioning of a single resource in AWS can be achieved using CloudFormation [RSpec](https://github.com/envato/cloudformation_rspec), [awspec](https://github.com/k1LoW/awspec) and others.
 Testing the provisioning of a single resource or even a single AWS CloudFormation stack is valuable and will give you 
 confidence that your change will behave in the way you think without any side effects.  When you have multiple developers
 working on the same code base, or develop over time or have different developers provisioning different stacks that must
@@ -23,8 +23,8 @@ We do not recommend you create a whole test installation of the Service Catalog 
 The management overhead of the installation and the complexity and delay it creates in your SDLC should be avoided and 
 instead you should invest that effort into better automated testing so you can scale.   
 
-We recommend you have at least a single canary account where you can provision products that will work together.  You 
-can use *actions* from the Service Catalog Tools to automate the testing and promotion of products across your accounts 
+We recommend you have at least a single [canary account](https://wa.aws.amazon.com/wat.concept.canary-deployment.en.html) where you can provision products that will work together.  You 
+can use *actions* from the Service Catalog Tools to automate the testing and promotion of products across your AWS Accounts 
 including a mandatory provisioning into the canary account.
 
 ## Managing source code
@@ -32,13 +32,13 @@ including a mandatory provisioning into the canary account.
 We recommend you do not modify a product version that you have shared or provisioned.  If you make a change to a product
 then you should change the version name.
 
-We have seen gitflow working well with product development.  Whilst building a product the developer uses a develop
-branch in git.  That develop version gets provisioned into the canary account for testing.  Once the testing is complete
-the branch in merged to master and then rebranched from master to create a new version.  This worked well for teams
+We have seen [gitflow](https://github.com/nvie/gitflow) working well with product development.  Whilst building a product the developer uses a develop
+branch in git.  That `develop` version gets provisioned into the canary account for testing.  Once the testing is complete
+the branch in merged to `master` and then rebranched from `master` to create a new version.  This worked well for teams
 where a single developer was building a single product.  If you have a product that is too big for a single developer
 then maybe the product needs to be split into smaller pieces.  There are features in the tools that allow you split
 products into smaller pieces.
 
 {{% notice note %}}
-If you would like to share your SDLC process please raise a github issue to share
+If you would like to share your SDLC process please raise a [github issue](https://github.com/aws-samples/aws-service-catalog-tools-workshop/issues) to share
 {{% /notice %}}

--- a/workshop/content/design-considerations/product-sdlc/_index.md
+++ b/workshop/content/design-considerations/product-sdlc/_index.md
@@ -33,8 +33,8 @@ We recommend you do not modify a product version that you have shared or provisi
 then you should change the version name.
 
 We have seen [gitflow](https://github.com/nvie/gitflow) working well with product development.  Whilst building a product the developer uses a develop
-branch in git.  That `develop` version gets provisioned into the canary account for testing.  Once the testing is complete
-the branch in merged to `master` and then rebranched from `master` to create a new version.  This worked well for teams
+branch in git.  That *develop* version gets provisioned into the canary account for testing.  Once the testing is complete
+the branch in merged to *master* and then rebranched from *master* to create a new version.  This worked well for teams
 where a single developer was building a single product.  If you have a product that is too big for a single developer
 then maybe the product needs to be split into smaller pieces.  There are features in the tools that allow you split
 products into smaller pieces.

--- a/workshop/content/design-considerations/selecting-a-factory-account/_index.md
+++ b/workshop/content/design-considerations/selecting-a-factory-account/_index.md
@@ -7,7 +7,7 @@ weight = 100
 
 ## What are we going to do?
 
-This article will help you choose which AWS account is most suitable to use for the Service Catalog Tools
+This article will help you choose which AWS Account is most suitable to use for the Service Catalog Tools
 
 
 ## Recommended background reading?
@@ -20,8 +20,8 @@ It is recommended that you have read the following:
 
 Currently, you can only have one factory per account but you can create multiple accounts each with their own factory.
 
-If multiple teams want to make use of Service Catalog Factory the default recommendation would be that each team have 
-their own instance.  The teams are then independent and can operate without impact of each other.  There is also a 
+If multiple teams want to make use of Service Catalog Factory the recommendation is that each team have 
+their own instance.  The teams are then independent and can operate without impacting each other.  There is also a 
 separation of concerns if there is a security factory account and a networking factory account.  This reduces the blast
 radius should there be an incident and it enables easier billing calculations.
 
@@ -34,5 +34,5 @@ may be easier to manage all of the provisioning from a single factory account.
 
 In order to select a factory account we need to consider how you are going to be using the framework.
 
-A common use case is where teams use the framework to build and provision security controls into 
+A common use case is where teams use the framework to build and provision security controls into accounts that are operating their customer facing applications.
 

--- a/workshop/content/every-day-use/100-creating-a-product/100-define-the-product.md
+++ b/workshop/content/every-day-use/100-creating-a-product/100-define-the-product.md
@@ -70,7 +70,7 @@ Using a good / unique commit message will help you understand what is going on l
 
 {{< figure src="/how-tos/creating-and-provisioning-a-product/CommitChanges.png" >}}
 
-We have just told the framework there is a product named aws-config-enable-config.  This product has no versions and so 
+We have just told the framework there is a product named `aws-config-enable-config`.  This product has no versions and so 
 it will not appear in AWS Service Catalog yet.
 
 ### Create the version
@@ -161,11 +161,11 @@ successfully:
 {{< figure src="/how-tos/creating-and-provisioning-a-product/SuccessfulFactoryRun.png" >}}
 
 {{% notice tip %}}
-You should see your commit message on this screen, it will help you know which version of ServiceCatalogFactory repo
+You should see your commit message on this screen, it will help you know which version of *ServiceCatalogFactory* repo
 the pipeline is processing.
 {{% /notice %}}
 
 Now that your *ServiceCatalogFactory* pipeline has completed you can view the newly created pipeline: 
 {{% codepipeline_pipeline_link "aws-config-enable-config-v1-pipeline" %}}
 
-You can safely ignore aws-config-enable-config-v1-pipeline has failed.  For the pipeline to succeed, we need to add the source code for it to work which we will do in the next step.
+You can safely ignore the `aws-config-enable-config-v1-pipeline has failed` warning.  For the pipeline to succeed, we need to add the source code for it to work which we will do in the next step.

--- a/workshop/content/every-day-use/100-creating-a-product/300-add-the-source-code.md
+++ b/workshop/content/every-day-use/100-creating-a-product/300-add-the-source-code.md
@@ -9,7 +9,7 @@ home_region = "eu-west-1"
 
 We are going to perform the following steps:
 
-- Add the source code for the version of the product we have just created
+- Add the source code for the version of the AWS Service Catalog product we have just created
 
 
 ## Step by step guide
@@ -35,7 +35,7 @@ When you configured your product version, you specified the following:
  </figure>
 
 
-We now need to create the CodeCommit repository and add the AWS CloudFormation template we are going to use for our
+We now need to create the AWS CodeCommit repository and add the AWS CloudFormation template we are going to use for our
 product into that repository.
 
 - Navigate to {{% codecommit_link %}}

--- a/workshop/content/every-day-use/150-creating-a-portfolio/_index.md
+++ b/workshop/content/every-day-use/150-creating-a-portfolio/_index.md
@@ -11,9 +11,7 @@ home_region = "eu-west-1"
 
 This tutorial will walk you through "{{% param title %}}" with a spoke account.
 
-We will assume you have:
- 
- - installed Service Catalog Puppet correctly
+We will assume you have installed Service Catalog Puppet correctly.
 
 We are going to perform the following steps:
 

--- a/workshop/content/every-day-use/190-creating-a-manifest/_index.md
+++ b/workshop/content/every-day-use/190-creating-a-manifest/_index.md
@@ -9,9 +9,7 @@ home_region = "eu-west-1"
 
 This tutorial will walk you through "{{% param title %}}" 
 
-We will assume you have:
- 
- - installed Service Catalog Puppet correctly
+We will assume you have installed Service Catalog Puppet correctly.
  
 We are going to perform the following steps:
 

--- a/workshop/content/installation/20-service-catalog-factory.md
+++ b/workshop/content/installation/20-service-catalog-factory.md
@@ -53,11 +53,11 @@ Service Catalog Factory can be installed via a pre-created AWS CloudFormation te
 
 {{< figure src="/how-tos/installation/acknowledge_create.png" height="250" width="900">}}
 
-- You will now see the stack status as `CREATE_IN_PROGRESS`
+- You will now see the stack status as *CREATE_IN_PROGRESS*
 
 {{< figure src="/how-tos/installation/create_in_progress_factory.png" height="200" width="900">}}
 
-- Wait for the stack status to go to `CREATE_COMPLETE`
+- Wait for the stack status to go to *CREATE_COMPLETE*
 
 {{< figure src="/how-tos/installation/create_complete_factory.png" height="200" width="900">}}
 

--- a/workshop/content/installation/20-service-catalog-factory.md
+++ b/workshop/content/installation/20-service-catalog-factory.md
@@ -12,7 +12,7 @@ aliases = [
 
 ### Navigate to CloudFormation
 
-- Select the CloudFormation Service.
+- Select the AWS CloudFormation Service.
 
 {{< figure src="/how-tos/installation/select_cloudformation.png" height="450" width="900">}}
 
@@ -27,7 +27,7 @@ Confirm that you are in the {{% param home_region %}} ({{% param home_region_nam
 {{< figure src="/how-tos/installation/create_stack.png" height="300" width="900">}}
 
 ### Select the pre-configured CloudFormation Template
-Service Catalog Factory can be installed via a pre-created CloudFormation template stored in S3 under the following URL:
+Service Catalog Factory can be installed via a pre-created AWS CloudFormation template stored in Amazon S3 under the following URL:
 > `https://service-catalog-tools.s3.eu-west-2.amazonaws.com/factory/latest/servicecatalog-factory-initialiser.template.yaml`
 
 - Paste this URL under 'Amazon S3 URL': 
@@ -53,40 +53,40 @@ Service Catalog Factory can be installed via a pre-created CloudFormation templa
 
 {{< figure src="/how-tos/installation/acknowledge_create.png" height="250" width="900">}}
 
-- You will now see the Stack Status as 'CREATE_IN_PROGRESS'
+- You will now see the stack status as `CREATE_IN_PROGRESS`
 
 {{< figure src="/how-tos/installation/create_in_progress_factory.png" height="200" width="900">}}
 
-- Wait for the Stack Status to go to CREATE_COMPLETE
+- Wait for the stack status to go to `CREATE_COMPLETE`
 
 {{< figure src="/how-tos/installation/create_complete_factory.png" height="200" width="900">}}
 
 ### What have we deployed?
 The following AWS resources have just been deployed into your AWS Account:
 
-#### CloudFormation Stacks
-The CodeBuild job created 2 CloudFormation Stacks which in turn deployed the resources listed below:
+#### AWS CloudFormation stacks
+The AWS CodeBuild job created two AWS CloudFormation stacks which in turn deployed the resources listed below:
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/cloudformation/home?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/factory_cloudformation.png" height="200" width="900">}}
 
-#### Factory CodeCommit Repository
-This repository holds the Service Catalog Factory YAML files which are used to configure AWS Service Catalog Portfolios and Products.
+#### Factory AWS CodeCommit repository
+This repository holds the Service Catalog Factory YAML files which are used to configure AWS Service Catalog portfolios and products.
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/codesuite/codecommit/repositories?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/factory_codecommit.png" height="200" width="900">}}
 
-#### Factory CodePipeline
-This CodePipeline is triggered by updates to the CodeCommit Repository. When run, it will create the Service Catalog Portfolios and Products defined in the portfolio files. 
+#### Factory AWS CodePipeline
+This AWS CodePipeline is triggered by updates to the AWS CodeCommit repository. When run, it will create the AWS Service Catalog portfolios and products defined in the portfolio files. 
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/codesuite/codepipeline/pipelines?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/factory_codepipeline.png" height="200" width="900">}}
 
-#### S3 Buckets
-An S3 Bucket was created to store artifacts for Service Catalog factory.
+#### Amazon S3 Buckets
+An Amazon S3 Bucket was created to store artifacts for Service Catalog factory.
 
 > URL: https://s3.console.aws.amazon.com/s3/home?region={{% param home_region %}}
 

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/10-puppet-account.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/10-puppet-account.md
@@ -59,11 +59,11 @@ Service Catalog Puppet can be installed via a pre-created AWS CloudFormation tem
 
 {{< figure src="/how-tos/installation/acknowledge_create.png" height="200" width="900">}}
 
-- You will now see the stack status as `CREATE_IN_PROGRESS`
+- You will now see the stack status as *CREATE_IN_PROGRESS*
 
 {{< figure src="/how-tos/installation/create_in_progress_puppet.png" height="200" width="900">}}
 
-- Wait for the stack status to go to `CREATE_COMPLETE`
+- Wait for the stack status to go to *CREATE_COMPLETE*
 
 {{< figure src="/how-tos/installation/create_complete_puppet.png" height="200" width="900">}}
 

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/10-puppet-account.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/10-puppet-account.md
@@ -9,7 +9,7 @@ home_region_name = 'Ireland'
 
 ### Navigate to CloudFormation
 
-- Select the CloudFormation Service.
+- Select the AWS CloudFormation service.
 
 {{< figure src="/how-tos/installation/select_cloudformation.png" height="450" width="900">}}
 
@@ -17,7 +17,7 @@ home_region_name = 'Ireland'
 Confirm you are in the {{% param home_region %}} ({{% param home_region_name %}}) region.
 {{% /notice %}}
 
-### Create a new CloudFormation Stack
+### Create a new AWS CloudFormation stack
 
 - Select 'Create Stack'
 
@@ -27,8 +27,8 @@ Confirm you are in the {{% param home_region %}} ({{% param home_region_name %}}
 Note that the Factory Initialization Stack has been deployed. If yours has not refer to 'Install Factory Process'
 {{% /notice %}}
 
-### Select the pre-configured CloudFormation Template
-Service Catalog Puppet can be installed via a pre-created CloudFormation Template stored in S3 under the following URL:
+### Select the pre-configured AWS CloudFormation template
+Service Catalog Puppet can be installed via a pre-created AWS CloudFormation template stored in Amazon S3 under the following URL:
 >  `https://service-catalog-tools.s3.eu-west-2.amazonaws.com/puppet/latest/servicecatalog-puppet-initialiser.template.yaml`
 
 
@@ -37,9 +37,9 @@ Service Catalog Puppet can be installed via a pre-created CloudFormation Templat
 
 {{< figure src="/how-tos/installation/specify_template_puppet.png" height="500" width="900">}}
 
-### Specify Stack Details
+### Specify AWS CloudFormation stack details
 
-- Specify the Stack details as follows:
+- Specify the AWS CloudFormation stack details as follows:
     - **Stack Name:** `puppet-initialization-stack`
     - **Enable Regions:** `{{% param home_region %}}`
     - **OrgIAMRoleArn:** `None` 
@@ -50,7 +50,7 @@ Service Catalog Puppet can be installed via a pre-created CloudFormation Templat
 
 {{< figure src="/how-tos/installation/specify_stack_details_puppet.png" height="600" width="900">}}
 
-### Create the Stack
+### Create the AWS CloudFormation stack
 
 - Leave Defaults for 'Configure Stack Options'
 - Hit Next
@@ -59,40 +59,40 @@ Service Catalog Puppet can be installed via a pre-created CloudFormation Templat
 
 {{< figure src="/how-tos/installation/acknowledge_create.png" height="200" width="900">}}
 
-- You will now see the Stack Status as 'CREATE_IN_PROGRESS'
+- You will now see the stack status as `CREATE_IN_PROGRESS`
 
 {{< figure src="/how-tos/installation/create_in_progress_puppet.png" height="200" width="900">}}
 
-- Wait for the Stack Status to go to CREATE_COMPLETE
+- Wait for the stack status to go to `CREATE_COMPLETE`
 
 {{< figure src="/how-tos/installation/create_complete_puppet.png" height="200" width="900">}}
 
 ### What have we deployed?
 The following AWS resources have just been deployed into your AWS Account:
 
-#### CloudFormation Stacks
-The CodeBuild job created 2 CloudFormation Stacks which in turn deployed the resources listed below
+#### AWS CloudFormation stacks
+The AWS CodeBuild job created two AWS CloudFormation stacks which in turn deployed the resources listed below
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/cloudformation/home?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/puppet_cloudformation.png" height="200" width="900">}}
 
-#### Puppet CodeCommit Repository
+#### Puppet AWS CodeCommit repository
 This respository holds the Service Catalog Puppet manifest YAML file which is used to configure provisioning and sharing.
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/codesuite/codecommit/repositories?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/puppet_codecommit.png" height="200" width="900">}}
 
-#### Puppet CodePipeline
-This CodePipeline is triggered by updates to the CodeCommit Repository. When run, it will create the Service Catalog Portfolios and Products defined in the portfolio files. 
+#### Puppet AWS CodePipeline
+This AWS CodePipeline is triggered by updates to the AWS CodeCommit repository. When run, it will create the Service Catalog portfolios and products defined in the portfolio files. 
 
 > URL: https://{{% param home_region %}}.console.aws.amazon.com/codesuite/codepipeline/pipelines?region={{% param home_region %}}
 
 {{< figure src="/how-tos/installation/puppet_codepipeline.png" height="200" width="900">}}
 
-#### S3 Buckets
-Three S3 Buckets were created to store artifacts for Service Catalog Puppet.
+#### Amazon S3 buckets
+Three Amazon S3 buckets were created to store artifacts for Service Catalog Puppet.
 
 > URL: https://s3.console.aws.amazon.com/s3/home?region={{% param home_region %}}
 

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/20-single-spokes.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/20-single-spokes.md
@@ -9,7 +9,7 @@ weight = 20
 
 You will need to bootstrap spoke accounts so you can share portfolios with them and provision products into them.
 
-Bootstrapping a spoke account will create an AWS CloudFormation stack in it.  This stack will contain the Puppet IAM Role (`PuppetRole`)
+Bootstrapping a spoke account will create an AWS CloudFormation stack in it.  This stack will contain the Puppet IAM Role (*PuppetRole*)
 which is needed by framework to perform actions in the spoke account.  
 
 ### Using the CLI
@@ -41,9 +41,9 @@ This will install the library and all of the dependencies.
 
 ### Restricting spokes
 
-The `PuppetRole` created by the framework has the *AdministratorAccess* IAM managed policy attached to it.  It is reccommended that you can define an [IAM Permission Boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) for the `PuppetRole` for any production applications of this framework.
+The *PuppetRole* created by the framework has the *AdministratorAccess* IAM managed policy attached to it.  It is reccommended that you can define an [IAM Permission Boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) for the *PuppetRole* for any production applications of this framework.
 
-The IAM Permission Boundary you provide should permit the `PuppetRole` to interact with AWS Service Catalog to accept shares, 
+The IAM Permission Boundary you provide should permit the *PuppetRole* to interact with AWS Service Catalog to accept shares, 
 manage portfolios and to add, provision and terminate products. In addition the IAM Role should allow the use of AWS SNS, 
 AWS EventBridge, AWS OpsCenter if you are making use of those features.  
 
@@ -92,7 +92,7 @@ _With a boundary_
 servicecatalog-puppet bootstrap-spoke-as <ACCOUNT_ID_OF_YOUR_PUPPET> <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> --permission-boundary arn:aws:iam::aws:policy/AdministratorAccess
 {{< / highlight >}}
 
-This will assume the role <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> before running `boostrap-spoke`.  This is useful if you do not 
+This will assume the role <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> before running *boostrap-spoke*.  This is useful if you do not 
 want to perform the AWS STS assume-role yourself. 
 
 Ensure you replace *&lt;ACCOUNT_ID_OF_YOUR_PUPPET&gt;* with the account id of the account you will be using as your 

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/20-single-spokes.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/20-single-spokes.md
@@ -9,14 +9,16 @@ weight = 20
 
 You will need to bootstrap spoke accounts so you can share portfolios with them and provision products into them.
 
-Bootstrapping a spoke account will create an AWS CloudFormation stack in it.  This stack will contain the PuppetRole 
+Bootstrapping a spoke account will create an AWS CloudFormation stack in it.  This stack will contain the Puppet IAM Role (`PuppetRole`)
 which is needed by framework to perform actions in the spoke account.  
 
 ### Using the CLI
 
-The following steps should be executed using the Service Catalog Puppet CLI which is an application built using Python 3.
+The following steps should be executed using the Service Catalog Puppet CLI which is an application built using Python 3.7.
 
 If you have not already installed the framework you can do so by following these steps:
+
+#### Create an isolated Python environment
 
 It is good practice to install Python libraries in isolated environments. 
 
@@ -26,6 +28,8 @@ You can create the a virtual environment using the following command:
 virtualenv --python=python3.7 venv
 source venv/bin/activate
 {{< / highlight >}}
+
+#### Install the package locally
 
 Once you have decided where to install the library you can install the package:
 
@@ -37,22 +41,19 @@ This will install the library and all of the dependencies.
 
 ### Restricting spokes
 
-The PuppetRole created by the framework has an *AdministratorAccess* IAM managed policy attached to it.  If you are not 
-happy you can provide an IAM Boundary for the Puppet role.
+The `PuppetRole` created by the framework has the *AdministratorAccess* IAM managed policy attached to it.  It is reccommended that you can define an [IAM Permission Boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) for the `PuppetRole` for any production applications of this framework.
 
-This permission boundary you provide should permit the PuppetRole to interact with AWS Service Catalog to accept shares, 
-manage portfolios and to add, provision and terminate products. In addition the role should allow the use of AWS SNS, 
+The IAM Permission Boundary you provide should permit the `PuppetRole` to interact with AWS Service Catalog to accept shares, 
+manage portfolios and to add, provision and terminate products. In addition the IAM Role should allow the use of AWS SNS, 
 AWS EventBridge, AWS OpsCenter if you are making use of those features.  
 
-Providing your own permission boundary is recommend for experienced users only.
-
-In order to use a permission boundary you will need to append the following to your commands:
+In order to use an IAM Permission Boundary you will need to append the following to your commands:
 
 {{< highlight bash >}}
 --permission-boundary arn:aws:iam::aws:policy/AdministratorAccess
 {{< / highlight >}}
 
-There will be an example of this for each command in these how tos.
+There will be an example of this for each command in these _how tos_.
 
 ### Bootstrapping a spoke
 
@@ -61,18 +62,18 @@ will execute as a role in the spoke account.
 
 Then you can run the following command: 
 
-_Without a boundary_
+_Without a permission boundary_
 {{< highlight bash >}}
 servicecatalog-puppet bootstrap-spoke <ACCOUNT_ID_OF_YOUR_PUPPET>
 {{< / highlight >}}
 
 
-_With a boundary_
+_With a permission boundary_
 {{< highlight bash >}}
 servicecatalog-puppet bootstrap-spoke <ACCOUNT_ID_OF_YOUR_PUPPET> --permission-boundary arn:aws:iam::aws:policy/AdministratorAccess
 {{< / highlight >}}
 
-Ensure you replace *&lt;ACCOUNT_ID_OF_YOUR_PUPPET&gt;* with the account id of the account you will be using as your 
+Ensure you replace *&lt;ACCOUNT_ID_OF_YOUR_PUPPET&gt;* with the AWS Account id of the AWS Account you will be using as your 
 puppet account.  
 
 
@@ -91,8 +92,8 @@ _With a boundary_
 servicecatalog-puppet bootstrap-spoke-as <ACCOUNT_ID_OF_YOUR_PUPPET> <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> --permission-boundary arn:aws:iam::aws:policy/AdministratorAccess
 {{< / highlight >}}
 
-This will assume the role <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> before running boostrap-spoke.  This is useful if you do not 
-want to perform the STS assume-role yourself. 
+This will assume the role <ARN_OF_ASSUMABLE_ROLE_IN_SPOKE> before running `boostrap-spoke`.  This is useful if you do not 
+want to perform the AWS STS assume-role yourself. 
 
 Ensure you replace *&lt;ACCOUNT_ID_OF_YOUR_PUPPET&gt;* with the account id of the account you will be using as your 
 puppet account.  

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/30-groups-of-spokes.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/30-groups-of-spokes.md
@@ -19,11 +19,11 @@ In your AWS Account you can find an AWS CodeBuild project named: `servicecatalog
 
 - Before you select _Start Build_ again, expand the _Environment variables override_ section. 
 
-- Set `OU_OR_PATH` to the OU path or AWS Organizational Unit ID that contains all of the spokes you want to bootstrap
+- Set *OU_OR_PATH* to the OU path or AWS Organizational Unit ID that contains all of the spokes you want to bootstrap
 
-- Set `IAM_ROLE_NAME` to the name of the IAM Role that is assumable in the spoke accounts - this must be the same name in all accounts
+- Set *IAM_ROLE_NAME* to the name of the IAM Role that is assumable in the spoke accounts - this must be the same name in all accounts
 
-- Set `IAM_ROLE_ARNS` to the ARNs you want to assume before assuming before the `IAM_ROLE_NAME`.  This is should you need to assume a role with cross account permissions.
+- Set *IAM_ROLE_ARNS* to the ARNs you want to assume before assuming before the *IAM_ROLE_NAME*.  This is should you need to assume a role with cross account permissions.
 
 - Click _Start Build_ again
 
@@ -74,7 +74,7 @@ servicecatalog-puppet bootstrap-spokes-in-ou /dev DevOpsAdminRole --permission-b
 {{< / highlight >}}
 
 
-If your current role does not allow you to list accounts in the AWS Organization or allow you to `assume-role` across AWS accounts you can 
+If your current role does not allow you to list accounts in the AWS Organization or allow you to *assume-role* across AWS accounts you can 
 specify an ARN of an IAM role that does. When you do so the framework will assume that IAM Role first and then perform the 
 bootstrapping.
 

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/30-groups-of-spokes.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/30-groups-of-spokes.md
@@ -9,29 +9,31 @@ weight = 30
 
 If you have enabled AWS Organizations support you may want to bootstrap all spokes within an organizational unit.
 
-Following these steps will allow you to bootstrap all accounts that exist within the same organizational unit.
+Following these steps will allow you to bootstrap all AWS Accounts that exist within the same organizational unit.
 
 ### Using the CodeBuild Project
 
-In your account you can find an AWS CodeBuild project named: servicecatalog-puppet-bootstrap-an-ou
+In your AWS Account you can find an AWS CodeBuild project named: `servicecatalog-puppet-bootstrap-an-ou`
 
-- Click start build
+- Click _Start Build_
 
-- Before you select start build again, expand the _Environment variables override_ section. 
+- Before you select _Start Build_ again, expand the _Environment variables override_ section. 
 
-- Set OU_OR_PATH to the OU path or organizational unit id that contains all of the spokes you want to bootstrap
+- Set `OU_OR_PATH` to the OU path or AWS Organizational Unit ID that contains all of the spokes you want to bootstrap
 
-- Set IAM_ROLE_NAME to the name of the IAM Role that is assumable in the spoke accounts - this must be the same name in all accounts
+- Set `IAM_ROLE_NAME` to the name of the IAM Role that is assumable in the spoke accounts - this must be the same name in all accounts
 
-- Set IAM_ROLE_ARNS to the ARNs you want to assume before assuming before the IAM_ROLE_NAME.  This is should you need to assume a role with cross account permissions.
+- Set `IAM_ROLE_ARNS` to the ARNs you want to assume before assuming before the `IAM_ROLE_NAME`.  This is should you need to assume a role with cross account permissions.
 
-- Click start build again
+- Click _Start Build_ again
 
 ### Using the CLI
 
-The following steps should be executed using the Service Catalog Puppet CLI which is an application built using Python 3.
+The following steps should be executed using the Service Catalog Puppet CLI which is an application built using Python 3.7.
 
 If you have not already installed the framework you can do so by following these steps:
+
+#### Create an isolated Python environment
 
 It is good practice to install Python libraries in isolated environments. 
 
@@ -42,6 +44,8 @@ virtualenv --python=python3.7 venv
 source venv/bin/activate
 {{< / highlight >}}
 
+#### Install the package locally
+
 Once you have decided where to install the library you can install the package:
 
 {{< highlight bash >}}
@@ -50,28 +54,28 @@ pip install aws-service-catalog-puppet
 
 This will install the library and all of the dependencies.
 
-#### Bootstrapping spokes in ou
+#### Bootstrapping spokes in OU
 
-You should export the credentials for the account that allows you to list accounts in the org and assume a role in each 
+You should export the credentials for the account that allows you to list accounts in the org and assume an IAM Role in each 
 of the spokes.
 
 Then you can run the following command: 
 
-_Without a boundary_
+_Without a Permission Boundary_
 {{< highlight bash >}}
 servicecatalog-puppet bootstrap-spokes-in-ou /dev DevOpsAdminRole
 {{< / highlight >}}
 
 In this example /dev is the ou path and DevOpsAdminRole is the name of the assumable role in each spoke account. 
 
-_With a boundary_
+_With a Permission Boundary_
 {{< highlight bash >}}
 servicecatalog-puppet bootstrap-spokes-in-ou /dev DevOpsAdminRole --permission-boundary arn:aws:iam::aws:policy/AdministratorAccess
 {{< / highlight >}}
 
 
-If your current role does not allow you to list accounts in the org or allow you to assume role cross account you can 
-specify an ARN of a role that does. When you do so the framework will assume that role first and then perform the 
+If your current role does not allow you to list accounts in the AWS Organization or allow you to `assume-role` across AWS accounts you can 
+specify an ARN of an IAM role that does. When you do so the framework will assume that IAM Role first and then perform the 
 bootstrapping.
 
 {{< highlight bash >}}

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/_index.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/_index.md
@@ -3,9 +3,9 @@ title = "Bootstrapping"
 weight = 20
 +++
 
-You will need to bootstrap your `puppet` account so you can setup the resources needed to run Service Catalog Puppet. 
+You will need to bootstrap your *puppet* account so you can setup the resources needed to run Service Catalog Puppet. 
 
-You will also need to bootstrap `spoke` accounts so you can share portfolios with them and provision products into them.
+You will also need to bootstrap *spoke* accounts so you can share portfolios with them and provision products into them.
 
 
 {{% children depth="1" showhidden="false" %}}

--- a/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/_index.md
+++ b/workshop/content/installation/30-service-catalog-puppet/20-bootstrapping/_index.md
@@ -3,9 +3,9 @@ title = "Bootstrapping"
 weight = 20
 +++
 
-You will need to bootstrap your puppet account so you can setup the resources needed to run Service Catalog Puppet. 
+You will need to bootstrap your `puppet` account so you can setup the resources needed to run Service Catalog Puppet. 
 
-You will also need to bootstrap spoke accounts so you can share portfolios with them and provision products into them.
+You will also need to bootstrap `spoke` accounts so you can share portfolios with them and provision products into them.
 
 
 {{% children depth="1" showhidden="false" %}}

--- a/workshop/content/installation/_index.md
+++ b/workshop/content/installation/_index.md
@@ -14,7 +14,7 @@ You will also need to decide which account to install these tools into.
 
 This account will contain the AWS CodePipelines and will need to be accessible to any accounts you would like to share 
 products with. If you want to use the optional AWS Organizations support you will need to install the tools into an 
-account where there is (or can be) a trust relationship with the Organizations master account.  You can install these 
+AWS Account where there is (or can be) a trust relationship with the AWS Organizations master account.  You can install these 
 tools into your master account but this is not recommended. 
 
 Both tools should be installed into the same region of the same account.

--- a/workshop/content/tools/_index.md
+++ b/workshop/content/tools/_index.md
@@ -7,7 +7,7 @@ weight = 11
 
 ## What are the Service Catalog Tools
 
-The Service Catalog Tools are a collection of open source tools authored to accelerate your use as AWS Service Catalog.
+The Service Catalog Tools are a collection of open source tools authored to accelerate your use as [AWS Service Catalog](https://aws.amazon.com/servicecatalog/).
 
 To find out more about the tools please read through the following:
 
@@ -16,14 +16,13 @@ To find out more about the tools please read through the following:
 
 **Service Catalog Factory** is part of a suite of open source Tools which have been built to compliment the AWS Service Catalog Service.
 
-Service Catalog Factory enables you to quickly build AWS CodePipelines that will create Service Catalog portfolios and populate them with products across multiple regions of your AWS Account.  You specify where in git the source code is for your products and you specify which regions you would like your products to exist and the framework will perform all of the undifferentiated heavy lifting for you.  
+Service Catalog Factory enables you to quickly build AWS CodePipelines that will create AWS Service Catalog portfolios and populate them with products across multiple regions of your AWS Account.  You specify where in git the source code is for your products and you specify which regions you would like your products to exist and the framework will perform all of the undifferentiated heavy lifting for you.  
 
 In addition, the pipelines the framework creates can perform functional tests and static
-analysis on your templates to help you with your SDLC.
+analysis on your templates to help you with your [Software Development Life-Cycle](https://en.wikipedia.org/wiki/Systems_development_life_cycle) (SDLC).
 
 
-Service Catalog Factory allows you to define Service Catalog portfolios and products using YAML. You can version your products and specify where the source
-code for them can be found. 
+Service Catalog Factory allows you to define AWS Service Catalog portfolios and products using [YAML](https://en.wikipedia.org/wiki/YAML). You can version your products and specify where the source code for them can be found. 
 
 You can configure the frameowrk to publish the portfolios, products and versions in each of your required AWS Regions.
 
@@ -34,29 +33,29 @@ Service Catalog in every enabled region of your hub account using AWS CodePipeli
 
 {{< figure src="/sc_factory.png" height="600" width="700">}}
 
-User interaction with the Framework is via a YAML file. The YAML file contains the definition of the Portfolios and Products you want to manage. Updates to the YAML file in AWS CodeCommit triggers the AWS CodePipeline to manage execute the tasks required.
+User interaction with the framework is via a YAML file. The YAML file contains the definition of the portfolios and products you want to manage. Updates to the YAML file in AWS CodeCommit triggers the AWS CodePipeline to manage execute the tasks required.
 
 
 ## What is Service Catalog Puppet
 
-**Service Catalog Puppet** is part of a suite of open source Tools which have been built to compliment the AWS Service Catalog Service.
+**Service Catalog Puppet** is part of a suite of open source tools which have been built to compliment the AWS Service Catalog Service.
 
-Service Catalog Puppet enables you to provision AWS Service Catalog Products into multiple Accounts and Regions across your AWS Estate.
+Service Catalog Puppet enables you to provision AWS Service Catalog Products into multiple AWS Accounts and Regions across your AWS estate.
 
-The Tool reduces the Operational burden of engineering a solution to support Portfolio Sharing and Product Launches across a large Enterprise and allows you to focus on writing the Products you require to support your Organizations needs.
+The Tool reduces the operational burden of engineering a solution to support portfolio sharing and product launches across an enterprise and allows you to focus on writing the products you require to support your organization's needs.
 
-Service Catalog Puppet makes use of a number of AWS Services including AWS CodePipeline, AWS CodeBuild and AWS CloudFormation to manage this for you.
+Service Catalog Puppet makes use of a number of AWS services including AWS CodePipeline, AWS CodeBuild and AWS CloudFormation to manage this for you.
 
 ## High-Level Architecture Diagram
 
 You use an AWS CodeBuild project in a central _hub_ account that provisions AWS
 Service Catalog Products into _spoke_ accounts on your behalf.  The framework
-takes care of cross account sharing and cross region product replication for
+takes care of cross-account sharing and cross region product replication for
 you.
 
 {{< figure src="/sc_puppet.png" height="600" width="800">}}
 
-User interaction with the Framework is via a YAML file. The YAML file contains the definition of the AWS Accounts you want to manage (using tags), the portfolios you want to share and the Products you want to launch.
+User interaction with the framework is via a YAML file. The YAML file contains the definition of the AWS Accounts you want to manage (using tags), the portfolios you want to share and the products you want to launch.
 
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Just correcting some AWS naming conventions and typos in the documentation. There were also some pages that were incomplete, which I tried to tail and complete.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
