### PR TITLE
aligned manifest with other activities

### DIFF
--- a/workshop/content/every-day-use/385-provisioning-a-stack/_index.md
+++ b/workshop/content/every-day-use/385-provisioning-a-stack/_index.md
@@ -29,7 +29,7 @@ We are going to perform the following steps to "{{% param title %}}":
 
 ## Step by step guide
 
-Here are the steps you need to follow to "{{% param title %}}"
+Here are the steps you need to follow for "{{% param title %}}"
 
 ### Things to note, before we start
 
@@ -101,7 +101,7 @@ Outputs:
 
 ## Provision a stack using Service Catalog Puppet
 
-_Now we are ready to add a lambda invocation to the manifest file._
+_Now we are ready to provision the stack using the manifest file._
 
 - Navigate to the {{% service_catalog_puppet_code_commit_repo_link %}}
 
@@ -124,7 +124,7 @@ stacks:
         default: "world"
     deploy_to:
       tags:
-        - tag: role:spoke
+        - tag: type:prod
           regions: regions_enabled
   {{< / highlight >}}
  </figure>
@@ -151,7 +151,7 @@ stacks:
         default: "world"
     deploy_to:
       tags:
-        - tag: role:spoke
+        - tag: type:prod
           regions: regions_enabled
   {{< / highlight >}}
  </figure>


### PR DESCRIPTION
*Description of changes:*

- 32:  corrected for grammar 
- 104: corrected activity description
- 127: corrected manifest tags to align with the other activities in the "every day use" section.  Without this change, a user who has been following along would not have the "role:spoke" tag and could be confused when nothing changes after the puppet pipeline run
- 154 - See line 127 explanation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
