### PR TITLE
Fixing #86 and #90 - Repo name typo, variable name typo

### DIFF
--- a/workshop/content/2021-workshop/300-provisioning-subnets/20-using-terraform.md
+++ b/workshop/content/2021-workshop/300-provisioning-subnets/20-using-terraform.md
@@ -133,7 +133,7 @@ workspace.
  <figure>
  {{< highlight js >}}
 
-variable "VPCId" {
+variable "VPCID" {
   type = string
 }
 
@@ -142,7 +142,7 @@ variable "SubnetCIDR" {
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = var.VPCId
+  vpc_id     = var.VPCID
   cidr_block = var.SubnetCIDR
 }
  {{< / highlight >}}

--- a/workshop/content/2021-workshop/300-provisioning-subnets/20-using-terraform.md
+++ b/workshop/content/2021-workshop/300-provisioning-subnets/20-using-terraform.md
@@ -43,7 +43,7 @@ Workspaces:
         Source:
           Provider: "CodeCommit"
           Configuration:
-            RepositoryName: "subnet"
+            RepositoryName: "subnet-terraform"
             BranchName: "main"
    {{< / highlight >}}
   </figure>
@@ -98,7 +98,7 @@ When you configured your product version, you specified the following version:
         Source:
           Provider: "CodeCommit"
           Configuration:
-            RepositoryName: "subnet"
+            RepositoryName: "subnet-terraform"
             BranchName: "main"
   {{< / highlight >}}
  </figure>


### PR DESCRIPTION
Corrected repository name and variable name typos

**Issue #86 & Issue #90**

*Description of changes:*

dd51481 - 46 and 101: Corrected repository name from subnet -> subnet-terraform in the code snippet.

af8d8e7 - 135 and 145: Corrected variable name from VPCId -> VPCID in the code snippet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
