### PR TITLE
doc: Fixed name of tool in documentation

### DIFF
--- a/workshop/content/2021-workshop/10-prerequisites/100-installation/30-service-catalog-puppet.md
+++ b/workshop/content/2021-workshop/10-prerequisites/100-installation/30-service-catalog-puppet.md
@@ -9,7 +9,7 @@ home_region_name = 'Ireland'
 
 
 ### Select the pre-configured AWS CloudFormation template
-Service Catalog Factory can be installed via a pre-created AWS CloudFormation template stored in Amazon S3. There are 
+Service Catalog Puppet can be installed via a pre-created AWS CloudFormation template stored in Amazon S3. There are 
 many configuration options for you to customise your installation.  For this workshop we will be using the following 
 quick link which has the settings already preconfigured for you:
 


### PR DESCRIPTION
The document describes the installation of Service Catalog Puppet and not Service Catalog Factory as mentioned.

*Issue #88*

*Description of changes:*
Updated the name of the tool that will be installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
